### PR TITLE
clean up some unsafety, help LLVM elide bounds checks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,52 +94,50 @@ macro_rules! FOR5 {
 }
 
 /// keccak-f[1600]
-pub fn keccakf(a: &mut [u64]) {
-    unsafe {
-        let mut b: [u64; 5] = [0; 5];
-        let mut t: u64;
-        let mut x: usize;
-        let mut y: usize;
+pub fn keccakf(a: &mut [u64; PLEN]) {
+    let mut b: [u64; 5] = [0; 5];
+    let mut t: u64;
+    let mut x: usize;
+    let mut y: usize;
 
-        for i in 0..24 {
-            // Theta
-            FOR5!(x, 1, {
-                *b.get_unchecked_mut(x) = 0;
-                FOR5!(y, 5, {
-                    *b.get_unchecked_mut(x) ^= *a.get_unchecked(x + y);
-                });
-            });
-
-            FOR5!(x, 1, {
-                FOR5!(y, 5, {
-                    *a.get_unchecked_mut(y + x) ^= *b.get_unchecked((x + 4) % 5) ^ b.get_unchecked((x + 1) % 5).rotate_left(1);
-                });
-            });
-
-            // Rho and pi
-            t = *a.get_unchecked(1);
-            x = 0;
-            REPEAT24!({
-                *b.get_unchecked_mut(0) = *a.get_unchecked(*PI.get_unchecked(x));
-                *a.get_unchecked_mut(*PI.get_unchecked(x)) = t.rotate_left(*RHO.get_unchecked(x));
-            }, {
-                t = *b.get_unchecked(0);
-                x += 1;
-            });
-
-            // Chi
+    for i in 0..24 {
+        // Theta
+        FOR5!(x, 1, {
+            b[x] = 0;
             FOR5!(y, 5, {
-                FOR5!(x, 1, {
-                    *b.get_unchecked_mut(x) = *a.get_unchecked(y + x);
-                });
-                FOR5!(x, 1, {
-                    *a.get_unchecked_mut(y + x) = *b.get_unchecked(x) ^ ((!b.get_unchecked((x + 1) % 5)) & b.get_unchecked((x + 2) % 5));
-                });
+                b[x] ^= a[x + y];
             });
+        });
 
-            // Iota
-            *a.get_unchecked_mut(0) ^= *RC.get_unchecked(i);
-        }
+        FOR5!(x, 1, {
+            FOR5!(y, 5, {
+                a[y + x] ^= b[(x + 4) % 5] ^ b[(x + 1) % 5].rotate_left(1);
+            });
+        });
+
+        // Rho and pi
+        t = a[1];
+        x = 0;
+        REPEAT24!({
+            b[0] = a[PI[x]];
+            a[PI[x]] = t.rotate_left(RHO[x]);
+        }, {
+            t = b[0];
+            x += 1;
+        });
+
+        // Chi
+        FOR5!(y, 5, {
+            FOR5!(x, 1, {
+                b[x] = a[y + x];
+            });
+            FOR5!(x, 1, {
+                a[y + x] = b[x] ^ ((!b[(x + 1) % 5]) & (b[(x + 2) % 5]));
+            });
+        });
+
+        // Iota
+        a[0] ^= RC[i];
     }
 }
 


### PR DESCRIPTION
Actually got faster (reproducible for me, may want to check on other machines)

**Benches**
After:
```
running 2 tests
test bench_sha3_256_input_4096_bytes ... bench:      21,322 ns/iter (+/- 2,177) = 192 MB/s
test keccakf_u64                     ... bench:         676 ns/iter (+/- 58) = 36 MB/s
```

Before:
```
running 2 tests
test bench_sha3_256_input_4096_bytes ... bench:      24,544 ns/iter (+/- 706) = 166 MB/s
test keccakf_u64                     ... bench:         771 ns/iter (+/- 104) = 32 MB/s
```

**Comparison**
After:
```
running 4 tests
test rust_crypto_sha3_256_input_32_bytes   ... bench:       1,822 ns/iter (+/- 721) = 17 MB/s
test rust_crypto_sha3_256_input_4096_bytes ... bench:      52,218 ns/iter (+/- 3,668) = 78 MB/s
test tiny_keccak_sha3_256_input_32_bytes   ... bench:         705 ns/iter (+/- 39) = 45 MB/s
test tiny_keccak_sha3_256_input_4096_bytes ... bench:      21,379 ns/iter (+/- 2,600) = 191 MB/s
```

Before:
```
running 4 tests
test rust_crypto_sha3_256_input_32_bytes   ... bench:       1,822 ns/iter (+/- 421) = 17 MB/s
test rust_crypto_sha3_256_input_4096_bytes ... bench:      52,126 ns/iter (+/- 3,583) = 78 MB/s
test tiny_keccak_sha3_256_input_32_bytes   ... bench:         808 ns/iter (+/- 64) = 39 MB/s
test tiny_keccak_sha3_256_input_4096_bytes ... bench:      25,114 ns/iter (+/- 3,347) = 163 MB/s
```

It would be nice to get rid of `as_bytes_slice` unsafety, but I don't see a way of doing it without likely hurting performance.