### PR TITLE
Fix borrows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,10 +142,11 @@ pub fn keccakf(a: &mut [u64; PLEN]) {
 }
 
 fn xorin(dst: &mut [u8], src: &[u8], len: usize) {
-    unsafe {
-        for i in 0..len {
-            *dst.get_unchecked_mut(i) ^= *src.get_unchecked(i);
-        }
+    // elide bounds checks; see Rust commit 6a7bc47
+    let dst = &mut dst[..len];
+    let src = &src[..len];
+    for i in 0..len {
+        dst[i] ^= src[i];
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,20 +156,6 @@ fn setout(src: &[u8], dst: &mut [u8], len: usize) {
 /// Total number of lanes.
 const PLEN: usize = 25;
 
-/// Lets cheat borrow checker.
-fn as_bytes_slice<'a, 'b>(ints: &'a [u64]) -> &'b [u8] {
-    unsafe {
-        ::core::slice::from_raw_parts(ints.as_ptr() as *mut u8, ints.len() * 8)
-    }
-}
-
-/// Lets cheat borrow checker... again.
-fn as_mut_bytes_slice<'a, 'b>(ints: &'a mut [u64]) -> &'b mut [u8] {
-    unsafe {
-        ::core::slice::from_raw_parts_mut(ints.as_mut_ptr() as *mut u8, ints.len() * 8)
-    }
-}
-
 /// This structure should be used to create keccak/sha3 hash.
 ///
 /// ```rust
@@ -233,6 +219,20 @@ impl Keccak {
         }
     }
 
+    fn a_bytes(&self) -> &[u8] {
+        let ints = &self.a;
+        unsafe {
+            ::core::slice::from_raw_parts(ints.as_ptr() as *mut u8, ints.len() * 8)
+        }
+    }
+
+    fn a_mut_bytes(&mut self) -> &mut [u8] {
+        let ints = &mut self.a;
+        unsafe {
+            ::core::slice::from_raw_parts_mut(ints.as_mut_ptr() as *mut u8, ints.len() * 8)
+        }
+    }
+
     impl_constructor!(new_shake128,  128, 0x1f);
     impl_constructor!(new_shake256,  256, 0x1f);
     impl_constructor!(new_keccak224, 224, 0x01);
@@ -265,8 +265,6 @@ impl Keccak {
 
     // Absorb input
     pub fn absorb(&mut self, input: &[u8]) {
-        let mut a = as_mut_bytes_slice(&mut self.a);
-
         let inlen = input.len();
         let mut rate = self.rate - self.offset;
 
@@ -274,7 +272,8 @@ impl Keccak {
         let mut ip = 0;
         let mut l = inlen;
         while l >= rate {
-            xorin(&mut a[self.offset..], &input[ip..], rate);
+            let offset = self.offset;
+            xorin(&mut self.a_mut_bytes()[offset..], &input[ip..], rate);
             keccakf(&mut self.a);
             ip += rate;
             l -= rate;
@@ -283,26 +282,25 @@ impl Keccak {
         }
 
         // Xor in the last block
-        xorin(&mut a[self.offset..], &input[ip..], l);
+        let offset = self.offset;
+        xorin(&mut self.a_mut_bytes()[offset..], &input[ip..], l);
         self.offset += l;
     }
 
     pub fn pad(&mut self) {
-        let mut a = as_mut_bytes_slice(&mut self.a);
-
         let offset = self.offset;
         let rate = self.rate;
 
+        let delim = self.delim;
         unsafe {
-            *a.get_unchecked_mut(offset) ^= self.delim;
-            *a.get_unchecked_mut(rate - 1) ^= 0x80;
+            let aa = self.a_mut_bytes();
+            *aa.get_unchecked_mut(offset) ^= delim;
+            *aa.get_unchecked_mut(rate - 1) ^= 0x80;
         }
     }
 
     // squeeze output
     pub fn squeeze(&mut self, output: &mut [u8]) {
-        let a = as_bytes_slice(&mut self.a);
-
         let outlen = output.len();
         let rate = self.rate;
 
@@ -310,12 +308,12 @@ impl Keccak {
         let mut op = 0;
         let mut l = outlen;
         while l >= rate {
-            setout(&a, &mut output[op..], rate);
+            setout(self.a_bytes(), &mut output[op..], rate);
             keccakf(&mut self.a);
             op += rate;
             l -= rate;
         }
 
-        setout(&a, &mut output[op..], l);
+        setout(self.a_bytes(), &mut output[op..], l);
     }
 }


### PR DESCRIPTION
Incidentally this improve performance slightly because the compiler
avoids some check caused by the extra unsafe code:

Old :
test bench_sha3_256_input_4096_bytes ... bench:      19,252 ns/iter (+/- 2,023) = 212 MB/s
test keccakf_u64                     ... bench:         591 ns/iter (+/- 234) = 42 MB/s

New:
test bench_sha3_256_input_4096_bytes ... bench:      18,195 ns/iter (+/- 851) = 225 MB/s
test keccakf_u64                     ... bench:         574 ns/iter (+/- 19) = 43 MB/s