### PR TITLE
Comparison with sha3

### DIFF
--- a/comparison/Cargo.toml
+++ b/comparison/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["debris <marek.kotewicz@gmail.com>"]
 
 [dependencies]
 tiny-keccak = { path = "../" }
-rust-crypto = { git = "https://github.com/DaGenix/rust-crypto.git" }
+sha3 = "^0.5.3"

--- a/comparison/benches/sha3.rs
+++ b/comparison/benches/sha3.rs
@@ -1,15 +1,10 @@
-//! should be started with:
-//! ```bash
-//! multirust run nightly cargo bench
-//! ```
-
 #![feature(test)]
 
 extern crate test;
 extern crate tiny_keccak;
-extern crate crypto;
+extern crate sha3;
 
-use crypto::digest::Digest;
+use sha3::{Sha3_256, Digest};
 
 use test::Bencher;
 
@@ -45,10 +40,9 @@ fn rust_crypto_sha3_256_input_32_bytes(b: &mut Bencher) {
     b.bytes = data.len() as u64;
 
     b.iter(|| {
-        let mut res: [u8; 32] = [0; 32];
-        let mut keccak = crypto::sha3::Sha3::sha3_256();
+        let mut keccak = Sha3_256::default();
         keccak.input(&data);
-        keccak.result(&mut res);
+        keccak.result();
     });
 }
 
@@ -58,9 +52,8 @@ fn rust_crypto_sha3_256_input_4096_bytes(b: &mut Bencher) {
     b.bytes = data.len() as u64;
 
     b.iter(|| {
-        let mut res: [u8; 32] = [0; 32];
-        let mut keccak = crypto::sha3::Sha3::sha3_256();
+        let mut keccak = Sha3_256::default();
         keccak.input(&data);
-        keccak.result(&mut res);
+        keccak.result();
     });
 }


### PR DESCRIPTION
`rust-crypto` is abandoned and [RustCrypto](https://github.com/RustCrypto) organization aims to succeed it. `sha3` is part of it.

I've taken your `f` implementation and applied some other modifications to code inherited from the `rust-crypto`. (I've attributed you in the license file if you are interested) I think it's worth to do comparison with the `sha3` crate not with the `rust-crypto`.

On my laptop I am getting the following results:
```
test rustcrypto_sha3_256_input_32_bytes    ... bench:         835 ns/iter (+/- 65) = 38 MB/s
test rustcrypto_sha3_256_input_4096_bytes  ... bench:      22,927 ns/iter (+/- 1,799) = 178 MB/s
test tiny_keccak_sha3_256_input_32_bytes   ... bench:         800 ns/iter (+/- 175) = 40 MB/s
test tiny_keccak_sha3_256_input_4096_bytes ... bench:      23,229 ns/iter (+/- 2,176) = 176 MB/s
```