### PR TITLE
Allow custom rate/delim

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -318,7 +318,8 @@ impl Keccak {
     }
 
     pub fn fill_block(&mut self) {
-        self.offset = self.rate;
+        self.keccakf();
+        self.offset = 0;
     }
 
     // squeeze output

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,7 +230,7 @@ impl_global_alias!(sha3_384,  384);
 impl_global_alias!(sha3_512,  512);
 
 impl Keccak {
-    fn new(rate: usize, delim: u8) -> Keccak {
+    pub fn new(rate: usize, delim: u8) -> Keccak {
         Keccak {
             a: [0; PLEN],
             offset: 0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -317,6 +317,10 @@ impl Keccak {
         aa[rate - 1] ^= 0x80;
     }
 
+    pub fn fill_block(&mut self) {
+        self.offset = self.rate;
+    }
+
     // squeeze output
     pub fn squeeze(&mut self, output: &mut [u8]) {
         let outlen = output.len();

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -153,3 +153,22 @@ fn long_string_sha3_512_parts() {
     let ref_ex: &[u8] = &expected;
     assert_eq!(ref_res, ref_ex);
 }
+
+#[test]
+fn fill_shake() {
+    const RATE: usize = 168;
+    let mut shake = Keccak::new_shake128();
+    shake.update(&[0x42; RATE / 2]);
+    let mut shake2 = shake.clone();
+
+    shake.update(&[0; RATE / 2]);
+    shake2.fill_block();
+
+    let mut res = [0; 32];
+    let mut res2 = [0; 32];
+
+    shake.finalize(&mut res);
+    shake2.finalize(&mut res2);
+
+    assert_eq!(res, res2);
+}


### PR DESCRIPTION
I try to implement `cSHAKE`.
According to the [specification](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-185.pdf), ~~it needs to use a different rate~~.

```
If N = "" and S = "":
    return SHAKE128(X, L);
Else:
    return KECCAK[256](bytepad(encode_string(N) || encode_string(S), 168) || X || 00, L).
```

> Note that the numbers 168 and 136 are rates (in bytes) of the KECCAK[256] and KECCAK[512] sponge functions, respectively; the characters 00 in the Courier New font in these definitions specify two zero bits.
