### PR TITLE
optimize xorin

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,8 +148,14 @@ fn setout(src: &[u8], dst: &mut [u8], len: usize) {
 fn xorin(dst: &mut [u8], src: &[u8]) {
     assert!(dst.len() <= src.len());
     let len = dst.len();
-    for i in 0..len {
-        dst[i] ^= src[i];
+    let mut dst_ptr = dst.as_mut_ptr();
+    let mut src_ptr = src.as_ptr();
+    for _ in 0..len {
+        unsafe {
+            *dst_ptr ^= *src_ptr;
+            src_ptr = src_ptr.offset(1);
+            dst_ptr = dst_ptr.offset(1);
+        }
     }
 }
 


### PR DESCRIPTION
`bench_sha3_256_input_4096_bytes` is 50% faster on this branch than on master

@tomusdrw can you review the pr and confirm benches results?