### PR TITLE
Optimisations and convert to use crunchy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ authors = ["debris <marek.kotewicz@gmail.com>"]
 keywords = ["sha3", "sha-3", "keccak", "crypto", "tiny"]
 categories = ["cryptography", "no-std"]
 
+[dependencies]
+crunchy = "0.1.6"
+
 [profile.dev]
 opt-level = 3  # Controls the --opt-level the compiler builds with
 debug = false   # Controls whether the compiler passes `-g`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,9 @@
 
 #![no_std]
 
+#[macro_use]
+extern crate crunchy;
+
 const RHO: [u32; 24] = [
      1,  3,  6, 10, 15, 21,
     28, 36, 45, 55,  2, 14,
@@ -60,84 +63,69 @@ const RC: [u64; 24] = [
     0x8000000080008081u64, 0x8000000000008080u64, 0x80000001u64, 0x8000000080008008u64
 ];
 
-macro_rules! REPEAT4 {
-    ($e: expr) => ( $e; $e; $e; $e; )
-}
-
-macro_rules! REPEAT5 {
-    ($e: expr) => ( $e; $e; $e; $e; $e; )
-}
-
-macro_rules! REPEAT6 {
-    ($e: expr) => ( $e; $e; $e; $e; $e; $e; )
-}
-
-macro_rules! REPEAT24 {
-    ($e: expr, $s: expr) => (
-        REPEAT6!({ $e; $s; });
-        REPEAT6!({ $e; $s; });
-        REPEAT6!({ $e; $s; });
-        REPEAT5!({ $e; $s; });
-        $e;
-    )
-}
-
-macro_rules! FOR5 {
-    ($v: expr, $s: expr, $e: expr) => {
-        $v = 0;
-        REPEAT4!({
-            $e;
-            $v += $s;
-        });
-        $e;
-    }
-}
-
+#[allow(unused_assignments)]
 /// keccak-f[1600]
 pub fn keccakf(a: &mut [u64; PLEN]) {
-    let mut b: [u64; 5] = [0; 5];
-    let mut t: u64;
-    let mut x: usize;
-    let mut y: usize;
+    let mut arrays: [[u64; 5]; 24] = [[0; 5]; 24];
 
-    for i in 0..24 {
-        // Theta
-        FOR5!(x, 1, {
-            b[x] = 0;
-            FOR5!(y, 5, {
-                b[x] ^= a[x + y];
-            });
-        });
+    unroll! {
+        for i in 0..24 {
+            // Theta
+            unroll! {
+                for x in 0..5 {
+                    arrays[i][x] = 0;
+                    unroll! {
+                        for y_count in 0..5 {
+                            let y = y_count * 5;
+                            arrays[i][x] ^= a[x + y];
+                        }
+                    }
+                }
+            }
 
-        FOR5!(x, 1, {
-            FOR5!(y, 5, {
-                a[y + x] ^= b[(x + 4) % 5] ^ b[(x + 1) % 5].rotate_left(1);
-            });
-        });
+            unroll! {
+                for x in 0..5 {
+                    unroll! {
+                        for y_count in 0..5 {
+                            let y = y_count * 5;
+                            a[y + x] ^= arrays[i][(x + 4) % 5] ^ arrays[i][(x + 1) % 5].rotate_left(1);
+                        }
+                    }
+                }
+            }
 
-        // Rho and pi
-        t = a[1];
-        x = 0;
-        REPEAT24!({
-            b[0] = a[PI[x]];
-            a[PI[x]] = t.rotate_left(RHO[x]);
-        }, {
-            t = b[0];
-            x += 1;
-        });
+            // Rho and pi
+            let mut last = a[1];
+            unroll! {
+                for x in 0..24 {
+                    arrays[i][0] = a[PI[x]];
+                    a[PI[x]] = last.rotate_left(RHO[x]);
+                    last = arrays[i][0];
+                }
+            }
 
-        // Chi
-        FOR5!(y, 5, {
-            FOR5!(x, 1, {
-                b[x] = a[y + x];
-            });
-            FOR5!(x, 1, {
-                a[y + x] = b[x] ^ ((!b[(x + 1) % 5]) & (b[(x + 2) % 5]));
-            });
-        });
+            // Chi
+            unroll! {
+                for y_step in 0..5 {
+                    let y = y_step * 5;
 
-        // Iota
-        a[0] ^= RC[i];
+                    unroll! {
+                        for x in 0..5 {
+                            arrays[i][x] = a[y + x];
+                        }
+                    }
+
+                    unroll! {
+                        for x in 0..5 {
+                            a[y + x] = arrays[i][x] ^ ((!arrays[i][(x + 1) % 5]) & (arrays[i][(x + 2) % 5]));
+                        }
+                    }
+                }
+            };
+
+            // Iota
+            a[0] ^= RC[i];
+        }
     }
 }
 


### PR DESCRIPTION
Basically I just converted a bunch of mutable variables to be constants and made the array zeroing simpler/faster, mostly by using the macros in `crunchy`. Unrolling `for i in 0..24` outer loop leads to a noticeable increase in compilation time but also massively increases the speed (probably because it allows more optimisations to be done on the `array[i][...]` accesses). I was looking at this repo because I wanted to convert it to use simd but it turns out there was some low-hanging optimisation fruit that doesn't require nightly.