### PR TITLE
Add support for half-duplex use

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -326,14 +326,17 @@ impl Keccak {
         // second foldp
         let mut op = 0;
         let mut l = output.len();
+        let mut offset = self.offset;
         while l >= self.rate {
             setout(self.a_bytes(), &mut output[op..], self.rate);
             keccakf(&mut self.a);
             op += self.rate;
             l -= self.rate;
+            offset = 0;
         }
 
         setout(self.a_bytes(), &mut output[op..], l);
+        self.offset = offset + l;
     }
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -329,7 +329,7 @@ impl Keccak {
         let mut rate = self.rate - self.offset;
         let mut offset = self.offset;
         while l >= rate {
-            setout(self.a_bytes(), &mut output[op..], rate);
+            setout(self.a_bytes()[offset..], &mut output[op..], rate);
             keccakf(&mut self.a);
             op += rate;
             l -= rate;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -326,12 +326,14 @@ impl Keccak {
         // second foldp
         let mut op = 0;
         let mut l = output.len();
+        let mut rate = self.rate - self.offset;
         let mut offset = self.offset;
-        while l >= self.rate {
-            setout(self.a_bytes(), &mut output[op..], self.rate);
+        while l >= rate {
+            setout(self.a_bytes(), &mut output[op..], rate);
             keccakf(&mut self.a);
-            op += self.rate;
+            op += rate;
             l -= self.rate;
+            rate = self.rate;
             offset = 0;
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -329,7 +329,7 @@ impl Keccak {
         let mut rate = self.rate - self.offset;
         let mut offset = self.offset;
         while l >= rate {
-            setout(self.a_bytes()[offset..], &mut output[op..], rate);
+            setout(&self.a_bytes()[offset..], &mut output[op..], rate);
             keccakf(&mut self.a);
             op += rate;
             l -= rate;
@@ -337,7 +337,7 @@ impl Keccak {
             offset = 0;
         }
 
-        setout(self.a_bytes()[offset..], &mut output[op..], l);
+        setout(&self.a_bytes()[offset..], &mut output[op..], l);
         self.offset = offset + l;
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,7 +190,15 @@ pub struct Keccak {
     a: [u64; PLEN],
     offset: usize,
     rate: usize,
-    delim: u8
+    delim: u8,
+//    state: SpongeState
+}
+
+/// The `SpongeState` enum describes the state of the internal sponge.
+/// When the sponge transitions from one state to another 
+enum SpongeState {
+    Absorbing,
+    Squeezing,
 }
 
 impl Clone for Keccak {
@@ -198,6 +206,7 @@ impl Clone for Keccak {
         let mut res = Keccak::new(self.rate, self.delim);
         res.a.copy_from_slice(&self.a);
         res.offset = self.offset;
+        //res.state = self.state;
         res
     }
 }
@@ -316,6 +325,8 @@ impl Keccak {
         aa[rate - 1] ^= 0x80;
     }
 
+    /// Fills the rest of the block with zero bits and applies permutation.
+    /// This implements `bytepad` as defined in NIST SP800-185 for cSHAKE etc.
     pub fn fill_block(&mut self) {
         self.keccakf();
         self.offset = 0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -332,7 +332,7 @@ impl Keccak {
             setout(self.a_bytes(), &mut output[op..], rate);
             keccakf(&mut self.a);
             op += rate;
-            l -= self.rate;
+            l -= rate;
             rate = self.rate;
             offset = 0;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,7 +337,7 @@ impl Keccak {
             offset = 0;
         }
 
-        setout(self.a_bytes(), &mut output[op..], l);
+        setout(self.a_bytes()[offset..], &mut output[op..], l);
         self.offset = offset + l;
     }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -155,6 +155,35 @@ fn long_string_sha3_512_parts() {
 }
 
 #[test]
+fn squeeze_multiple() {
+    let mut sha3 = Keccak::new_sha3_512();
+    let data: Vec<u8> = From::from("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.");
+
+    sha3.update(&data);
+    let mut res: [u8; 64] = [0; 64];
+    sha3.squeeze(&mut res[0..10]);
+    sha3.squeeze(&mut res[10..30]);
+    sha3.squeeze(&mut res[30..60]);
+    sha3.squeeze(&mut res[60..60]);
+    sha3.squeeze(&mut res[60..64]);
+
+    let expected = vec![
+        0xf3, 0x2a, 0x94, 0x23, 0x55, 0x13, 0x51, 0xdf,
+        0x0a, 0x07, 0xc0, 0xb8, 0xc2, 0x0e, 0xb9, 0x72,
+        0x36, 0x7c, 0x39, 0x8d, 0x61, 0x06, 0x60, 0x38,
+        0xe1, 0x69, 0x86, 0x44, 0x8e, 0xbf, 0xbc, 0x3d,
+        0x15, 0xed, 0xe0, 0xed, 0x36, 0x93, 0xe3, 0x90,
+        0x5e, 0x9a, 0x8c, 0x60, 0x1d, 0x9d, 0x00, 0x2a,
+        0x06, 0x85, 0x3b, 0x97, 0x97, 0xef, 0x9a, 0xb1,
+        0x0c, 0xbd, 0xe1, 0x00, 0x9c, 0x7d, 0x0f, 0x09
+    ];
+
+    let ref_res: &[u8] = &res;
+    let ref_ex: &[u8] = &expected;
+    assert_eq!(ref_res, ref_ex);
+}
+
+#[test]
 fn fill_shake() {
     const RATE: usize = 168;
     let mut shake = Keccak::new_shake128();


### PR DESCRIPTION
This patch improves the API by allowing squeezing output any number of times, and switching between absorbing and squeezing any number of times.

Methods `absorb` and `squeeze` automatically keep track of the current offset in the Keccak state and apply necessary padding and/or permutation when transitioning from one mode to another.

As a result, `XofReader` is changed to a simple type alias and can be removed in the long term. Note that `XofReader` does not allow switching back to absorbing.

The rationale for half-duplex API is to enable use of Keccak in cryptographic protocol that employ "random oracle" via a Fiat-Shamir transform. Such protocols have to switch between committing some data (absorbing into a sponge) and generating challenges (squeezing the sponge).