### PR TITLE
Add a test for overlapping buffers (WAS: Don't unroll outer loop for speed™)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 Cargo.lock
 *.swp
+.idea


### PR DESCRIPTION
Not unrolling the outer loop seems to speed up hashing quite significally:

Original (unrolled):
```
running 3 tests
test bench_keccak_256_with_empty_input   ... bench:         557 ns/iter (+/- 46)
test bench_keccak_256_with_large_input   ... bench:      17,288 ns/iter (+/- 1,871) = 236 MB/s
test bench_keccak_256_with_typical_input ... bench:         577 ns/iter (+/- 28) = 88 MB/s
```

This branch (not unrolled):
```
running 3 tests
test bench_keccak_256_with_empty_input   ... bench:         487 ns/iter (+/- 25)
test bench_keccak_256_with_large_input   ... bench:      14,645 ns/iter (+/- 675) = 279 MB/s
test bench_keccak_256_with_typical_input ... bench:         495 ns/iter (+/- 32) = 103 MB/s
```

"Inspired" by https://github.com/RustCrypto/sponges/blob/master/keccak/src/lib.rs#L138

Running benchmarks from the `keccak-hash` crate so we can compare to the numbers [here](https://github.com/paritytech/keccak-hash/pull/1).