### PR TITLE
Implement `Hasher` for Keccak

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,8 @@
 #[macro_use]
 extern crate crunchy;
 
+use core::hash::Hasher;
+
 const RHO: [u32; 24] = [
      1,  3,  6, 10, 15, 21,
     28, 36, 45, 55,  2, 14,
@@ -333,6 +335,19 @@ impl Keccak {
         keccakf(&mut self.a);
 
         XofReader { keccak: self, offset: 0 }
+    }
+}
+
+impl Hasher for Keccak {
+    fn write(&mut self, bytes: &[u8]) {
+        self.update(bytes);
+    }
+
+    fn finish(&self) -> u64 {
+        let mut out = [0u8; 8];
+        self.clone().finalize(&mut out);
+        (out[7] as u64) << 56 | (out[6] as u64) << 48 | (out[5] as u64) << 40 | (out[4] as u64) << 32 |
+            (out[3] as u64) << 24 | (out[2] as u64) << 16 | (out[1] as u64) << 8 | (out[0] as u64)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@
 #[macro_use]
 extern crate crunchy;
 
-use core::hash::Hasher;
+use core::hash::{Hasher, BuildHasher};
 
 const RHO: [u32; 24] = [
      1,  3,  6, 10, 15, 21,
@@ -348,6 +348,14 @@ impl Hasher for Keccak {
         self.clone().finalize(&mut out);
         (out[7] as u64) << 56 | (out[6] as u64) << 48 | (out[5] as u64) << 40 | (out[4] as u64) << 32 |
             (out[3] as u64) << 24 | (out[2] as u64) << 16 | (out[1] as u64) << 8 | (out[0] as u64)
+    }
+}
+
+impl BuildHasher for Keccak {
+    type Hasher = Self;
+
+    fn build_hasher(&self) -> Self::Hasher {
+        self.clone()
     }
 }
 


### PR DESCRIPTION
This allows hashing any type that implements `Hash`.

Also, this implements `BuildHasher` as `Clone` so that you can use `Keccak` in a `HashMap` if you want to. There's not really any use for that but we might as well allow it.