### PR TITLE
Replace some unsafe with safe Rust without performance regression

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,16 +132,7 @@ fn setout(src: &[u8], dst: &mut [u8], len: usize) {
 
 fn xorin(dst: &mut [u8], src: &[u8]) {
     assert!(dst.len() <= src.len());
-    let len = dst.len();
-    let mut dst_ptr = dst.as_mut_ptr();
-    let mut src_ptr = src.as_ptr();
-    for _ in 0..len {
-        unsafe {
-            *dst_ptr ^= *src_ptr;
-            src_ptr = src_ptr.offset(1);
-            dst_ptr = dst_ptr.offset(1);
-        }
-    }
+    dst.iter_mut().zip(src.iter()).for_each(|(a, b)| *a ^= b);
 }
 
 /// Total number of lanes.


### PR DESCRIPTION
There seems to be no performance regression. I actually noticed a small improvement.

With unsafe:
```
test bench_sha3_256_input_4096_bytes ... bench:      13,141 ns/iter (+/- 890) = 311 MB/s
test keccakf_u64                     ... bench:         413 ns/iter (+/- 31) = 60 MB/s
```

Without unsafe:
```
test bench_sha3_256_input_4096_bytes ... bench:      12,986 ns/iter (+/- 1,054) = 315 MB/s
test keccakf_u64                     ... bench:         409 ns/iter (+/- 27) = 61 MB/s
```