### PR TITLE
Add missing features to build.rs check

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -5,7 +5,10 @@
     feature = "cshake",
     feature = "kmac",
     feature = "tuple_hash",
-    feature = "parallel_hash"
+    feature = "parallel_hash",
+    feature = "k12",
+    feature = "fips202",
+    feature = "sp800"
 )))]
 compile_error!(
     "You need to specify at least one hash function you intend to use. \


### PR DESCRIPTION
The feature check in build.rs was missing k12, fips202, and sp800.