### PR TITLE
Add `repository` and `documentation` metadata.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,8 @@
 edition = "2018"
 description = "An implementation of Keccak derived functions."
 homepage = "https://github.com/debris/tiny-keccak"
+documentation = "https://docs.rs/tiny-keccak/"
+repository = "https://github.com/debris/tiny-keccak"
 license = "CC0-1.0"
 name = "tiny-keccak"
 version = "2.0.1"


### PR DESCRIPTION
- `repository` is used by `docs.rs` to link to the project's repo (The homepage is not shown).
- `documentation` is used by `crates.io` to link to the documentation page.