### PR TITLE
feature: Expose KeccakState::reset

### DIFF
--- a/src/keccak.rs
+++ b/src/keccak.rs
@@ -53,6 +53,11 @@ impl Keccak {
             state: KeccakState::new(bits_to_rate(bits), Self::DELIM),
         }
     }
+
+    /// Resets the internal state
+    pub fn reset(&mut self) {
+        self.state.reset();
+    }
 }
 
 impl Hasher for Keccak {


### PR DESCRIPTION
This creates a public function, `Keccak::reset`, which allows the state to be reset/zeroed out

Fixes #46 