### PR TITLE
towards support for `digest::Digest`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 crunchy = "0.2.2"
+digest = { version = "0.9.0", optional=false, default_features = false }
+generic-array = "0.14.5"
 
 [profile.dev]
 opt-level = 3  # Controls the --opt-level the compiler builds with

--- a/src/keccak.rs
+++ b/src/keccak.rs
@@ -1,6 +1,8 @@
 //! The `Keccak` hash functions.
 
-use super::{bits_to_rate, keccakf::KeccakF, Hasher, KeccakState};
+use core::marker::PhantomData;
+
+use super::{bits_to_rate, keccakf::KeccakF, Hasher, KeccakState, Version, V224, V256, V384, V512};
 
 /// The `Keccak` hash functions defined in [`Keccak SHA3 submission`].
 ///
@@ -13,49 +15,76 @@ use super::{bits_to_rate, keccakf::KeccakF, Hasher, KeccakState};
 ///
 /// [`Keccak SHA3 submission`]: https://keccak.team/files/Keccak-submission-3.pdf
 #[derive(Clone)]
-pub struct Keccak {
+pub struct Keccak<V: Version> {
     state: KeccakState<KeccakF>,
+    _v: PhantomData<V>,
 }
 
-impl Keccak {
-    const DELIM: u8 = 0x01;
 
+impl Keccak<V224> {
     /// Creates  new [`Keccak`] hasher with a security level of 224 bits.
     ///
     /// [`Keccak`]: struct.Keccak.html
-    pub fn v224() -> Keccak {
+    pub fn v224() -> Self {
         Keccak::new(224)
     }
+}
 
+impl Default for Keccak<V224> {
+    fn default() -> Self { Keccak::v224() }
+}
+
+impl Keccak<V256> {
     /// Creates  new [`Keccak`] hasher with a security level of 256 bits.
     ///
     /// [`Keccak`]: struct.Keccak.html
-    pub fn v256() -> Keccak {
+    pub fn v256() -> Self {
         Keccak::new(256)
     }
+}
 
+impl Default for Keccak<V256> {
+    fn default() -> Self { Keccak::v256() }
+}
+
+impl Keccak<V384> {
     /// Creates  new [`Keccak`] hasher with a security level of 384 bits.
     ///
     /// [`Keccak`]: struct.Keccak.html
-    pub fn v384() -> Keccak {
+    pub fn v384() -> Self {
         Keccak::new(384)
     }
+}
 
+impl Default for Keccak<V384> {
+    fn default() -> Self { Keccak::v384() }
+}
+
+impl Keccak<V512> {
     /// Creates  new [`Keccak`] hasher with a security level of 512 bits.
     ///
     /// [`Keccak`]: struct.Keccak.html
-    pub fn v512() -> Keccak {
+    pub fn v512() -> Self {
         Keccak::new(512)
     }
+}
 
-    fn new(bits: usize) -> Keccak {
+impl Default for Keccak<V512> {
+    fn default() -> Self { Keccak::v512() }
+}
+
+impl <V: Version>Keccak<V> {
+    const DELIM: u8 = 0x01;
+
+    fn new(bits: usize) -> Self {
         Keccak {
             state: KeccakState::new(bits_to_rate(bits), Self::DELIM),
+            _v: PhantomData,
         }
     }
 }
 
-impl Hasher for Keccak {
+impl <V: Version> Hasher for Keccak<V> {
     /// Absorb additional input. Can be called multiple times.
     ///
     /// # Example
@@ -89,5 +118,33 @@ impl Hasher for Keccak {
     /// ```
     fn finalize(self, output: &mut [u8]) {
         self.state.finalize(output);
+    }
+}
+
+/// [`digest::FixedOutput`] implementation allows [`Sha3`] to be used as a [`digest::Digest`]
+impl <V: Version> digest::FixedOutput for Keccak<V>
+{
+    type OutputSize = V;
+
+    fn finalize_into(self, out: &mut digest::generic_array::GenericArray<u8, Self::OutputSize>) {
+        self.finalize(out);
+    }
+
+    fn finalize_into_reset(&mut self, out: &mut digest::generic_array::GenericArray<u8, Self::OutputSize>) {
+        self.clone().finalize(out);
+        self.state.reset()
+    }
+}
+
+impl <V: Version>digest::Update for Keccak<V>{
+    fn update(&mut self, data: impl AsRef<[u8]>) {
+        self.state.update(data.as_ref())
+    }
+}
+
+
+impl <V: Version>digest::Reset for Keccak<V>{
+    fn reset(&mut self) {
+        self.state.reset()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,6 +221,8 @@ pub trait Hasher {
     fn finalize(self, output: &mut [u8]);
 }
 
+
+
 /// A trait used to convert [`Hasher`] into it's [`Xof`] counterpart.
 ///
 /// # Example
@@ -265,6 +267,25 @@ pub trait Xof {
     /// A method used to retrieve another part of hash function output.
     fn squeeze(&mut self, output: &mut [u8]);
 }
+
+/// Hasher version marker trait, used to support [`digest::Digest`]
+pub trait Version: generic_array::ArrayLength<u8> {}
+
+/// 224-bit digest marker type
+pub type V224 = digest::consts::U28;
+impl Version for V224 {}
+
+/// 256-bit digest marker type
+pub type V256 = digest::consts::U32;
+impl Version for V256 {}
+
+/// 348-bit digest marker type
+pub type V384 = digest::consts::U48;
+impl Version for V384 {}
+
+/// 512-bit digest marker type
+pub type V512 = digest::consts::U64;
+impl Version for V512 {}
 
 struct EncodedLen {
     offset: usize,


### PR DESCRIPTION
hey there, thanks for making a neat crate! i'm attempting to use this with some cryptographic crates that require
 hashers implement the `digest::Digest` trait.

this PR refactors the `Sha3` and `Keccak` types to use generics and adds [`digest::FixedOutput`](https://docs.rs/digest/0.9.0/digest/trait.FixedOutput.html), `digest::Reset` and `Default` implementations for compatibility with the [`digest::Digest`](https://docs.rs/digest/0.9.0/digest/trait.Digest.html) trait, if that's something you would be interested in?

this is a breaking change as objects are now typed based on their output width.

note that this targets `digest@0.9.0` as the wider ecosystem has not yet updated to `0.10.0`