### PR TITLE
risc0-zkvm: add accelerator support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 crunchy = "0.2.2"
+risc0-zkvm = { path = "../risc0/risc0/zkvm", default-features = false }
 
 [profile.dev]
 opt-level = 3  # Controls the --opt-level the compiler builds with

--- a/src/keccak.rs
+++ b/src/keccak.rs
@@ -1,6 +1,7 @@
 //! The `Keccak` hash functions.
 
 use super::{bits_to_rate, keccakf::KeccakF, Hasher, KeccakState};
+use risc0_zkvm::guest::env;
 
 /// The `Keccak` hash functions defined in [`Keccak SHA3 submission`].
 ///
@@ -70,7 +71,7 @@ impl Hasher for Keccak {
     /// # }
     /// ```
     fn update(&mut self, input: &[u8]) {
-        self.state.update(input);
+        env::keccak_update(input);
     }
 
     /// Pad and squeeze the state to the output.
@@ -88,6 +89,6 @@ impl Hasher for Keccak {
     /// #
     /// ```
     fn finalize(self, output: &mut [u8]) {
-        self.state.finalize(output);
+        env::keccak_finalize(output);
     }
 }


### PR DESCRIPTION
This is a first draft of patching the crate. There are some nuances that we may want to consider addressing before merging such as concurrent hashers. Placing this in draft for the time-being but early comments are welcome.